### PR TITLE
Feature/questionnaire morning night api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Django基本設定
+DJANGO_SECRET_KEY=replace-with-your-secret
+DJANGO_DEBUG=true
+DJANGO_ALLOWED_HOSTS=*
+DJANGO_SETTINGS_MODULE=backend.config.settings
+
+# Django DB設定（Supabaseを使う場合でも一応記載）
+DJANGO_DB_ENGINE=django.db.backends.sqlite3
+DJANGO_DB_NAME=db.sqlite3
+DJANGO_DB_USER=
+DJANGO_DB_PASSWORD=
+DJANGO_DB_HOST=
+DJANGO_DB_PORT=
+
+# Supabase設定
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-supabase-service-or-anon-key
+
+# CORS設定
+CORS_ALLOW_ALL_ORIGINS=true
+CORS_ALLOWED_ORIGINS=
+CORS_ALLOW_CREDENTIALS=false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 *.sqlite3
 .env
+.env.local

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -1,9 +1,10 @@
 from django.urls import include, path
-from rest_framework.routers import DefaultRouter
+
+from backend.apps.common.routers import NoFormatSuffixRouter
 
 from .views import CurrentUserView, UserProfileViewSet
 
-router = DefaultRouter()
+router = NoFormatSuffixRouter(trailing_slash=False)
 router.register("profiles", UserProfileViewSet, basename="user-profile")
 
 urlpatterns = [

--- a/backend/apps/common/__init__.py
+++ b/backend/apps/common/__init__.py
@@ -1,0 +1,1 @@
+# Common utilities for backend apps

--- a/backend/apps/common/routers.py
+++ b/backend/apps/common/routers.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from rest_framework.routers import DefaultRouter, SimpleRouter
+
+
+class NoFormatSuffixRouter(SimpleRouter):
+    """
+    format_suffix_patternsを適用しないルーター。
+    複数のルーターを使用する際のコンバーター重複登録エラーを防ぐ。
+    SimpleRouterを継承し、DefaultRouterのformat_suffix_patternsを回避。
+    """
+
+    include_root_view = True
+    routes = DefaultRouter.routes

--- a/backend/apps/conditions/urls.py
+++ b/backend/apps/conditions/urls.py
@@ -1,8 +1,8 @@
-from rest_framework.routers import DefaultRouter
+from backend.apps.common.routers import NoFormatSuffixRouter
 
 from .views import ConditionViewSet
 
-router = DefaultRouter()
+router = NoFormatSuffixRouter(trailing_slash=False)
 router.register("conditions", ConditionViewSet, basename="condition")
 
 urlpatterns = router.urls

--- a/backend/apps/logs/urls.py
+++ b/backend/apps/logs/urls.py
@@ -1,8 +1,8 @@
-from rest_framework.routers import DefaultRouter
+from backend.apps.common.routers import NoFormatSuffixRouter
 
 from .views import LogEntryViewSet
 
-router = DefaultRouter()
+router = NoFormatSuffixRouter(trailing_slash=False)
 router.register("logs", LogEntryViewSet, basename="log-entry")
 
 urlpatterns = router.urls

--- a/backend/apps/mascots/urls.py
+++ b/backend/apps/mascots/urls.py
@@ -1,8 +1,8 @@
-from rest_framework.routers import DefaultRouter
+from backend.apps.common.routers import NoFormatSuffixRouter
 
 from .views import MascotViewSet
 
-router = DefaultRouter()
+router = NoFormatSuffixRouter(trailing_slash=False)
 router.register("mascots", MascotViewSet, basename="mascot")
 
 urlpatterns = router.urls

--- a/backend/apps/questionnaires/README.md
+++ b/backend/apps/questionnaires/README.md
@@ -51,7 +51,7 @@ POST /api/questionnaire/night
 |------------|-----|------|------|
 | `mood` | string | 必須 | 気分（選択肢: `"絶好調"`, `"普通"`, `"モヤモヤ"`, `"つらい"`） |
 | `condition` | string | 必須 | 体調（選択肢: `"軽い"`, `"ふつう"`, `"だるい"`） |
-| `free_text` | string | 任意 | 自由入力テキスト（最大1000文字、現在は未使用） |
+| `free_text` | string | 任意 | 自由入力テキスト（最大1000文字、朝アンケートの場合は`morning_note`、夜アンケートの場合は`night_note`として保存されます） |
 
 ## レスポンス形式
 
@@ -62,8 +62,10 @@ POST /api/questionnaire/night
   "uuid": "550e8400-e29b-41d4-a716-446655440000",
   "morning_mood": "普通",
   "morning_condition": "軽い",
+  "morning_note": "今日は調子が良いです",
   "night_mood": null,
   "night_condition": null,
+  "night_note": null,
   "created_at": "2026-01-29T02:00:00.000Z",
   "updated_at": "2026-01-29T02:00:00.000Z"
 }
@@ -242,8 +244,10 @@ async function submitMorningQuestionnaire(
 | `uuid` | text | Supabaseの`public.users`テーブルの`uuid`（主キー） |
 | `morning_mood` | text | 朝の気分（`"絶好調"`, `"普通"`, `"モヤモヤ"`, `"つらい"`のいずれか） |
 | `morning_condition` | text | 朝の体調（`"軽い"`, `"ふつう"`, `"だるい"`のいずれか） |
+| `morning_note` | text | 朝の自由入力テキスト（最大1000文字） |
 | `night_mood` | text | 夜の気分（`"絶好調"`, `"普通"`, `"モヤモヤ"`, `"つらい"`のいずれか） |
 | `night_condition` | text | 夜の体調（`"軽い"`, `"ふつう"`, `"だるい"`のいずれか） |
+| `night_note` | text | 夜の自由入力テキスト（最大1000文字） |
 | `created_at` | timestamp | レコード作成日時 |
 | `updated_at` | timestamp | レコード更新日時 |
 
@@ -251,18 +255,18 @@ async function submitMorningQuestionnaire(
 
 1. **同じ日の既存レコードがある場合**:
    - 既存レコードを削除してから新規レコードを作成
-   - 朝アンケート送信時: `morning_mood`と`morning_condition`を更新、`night_mood`と`night_condition`は既存値を保持（なければ`null`）
-   - 夜アンケート送信時: `night_mood`と`night_condition`を更新、`morning_mood`と`morning_condition`は既存値を保持（なければ`null`）
+   - 朝アンケート送信時: `morning_mood`、`morning_condition`、`morning_note`を更新、`night_mood`、`night_condition`、`night_note`は既存値を保持（なければ`null`）
+   - 夜アンケート送信時: `night_mood`、`night_condition`、`night_note`を更新、`morning_mood`、`morning_condition`、`morning_note`は既存値を保持（なければ`null`）
 
 2. **同じ日の既存レコードがない場合**:
    - 新規レコードを作成
-   - 朝アンケート送信時: `morning_mood`と`morning_condition`を設定、`night_mood`と`night_condition`は`null`
-   - 夜アンケート送信時: `night_mood`と`night_condition`を設定、`morning_mood`と`morning_condition`は`null`
+   - 朝アンケート送信時: `morning_mood`、`morning_condition`、`morning_note`を設定、`night_mood`、`night_condition`、`night_note`は`null`
+   - 夜アンケート送信時: `night_mood`、`night_condition`、`night_note`を設定、`morning_mood`、`morning_condition`、`morning_note`は`null`
 
 ## 注意事項
 
 1. **認証**: 現在は認証不要（`AllowAny`）ですが、`X-User-UUID`ヘッダーは必須です
-2. **自由入力**: `free_text`フィールドは現在未使用です。将来的に別テーブルで管理する予定です
+2. **自由入力**: `free_text`フィールドは、朝アンケートの場合は`morning_note`、夜アンケートの場合は`night_note`として`users_condition`テーブルに保存されます
 3. **日付判定**: 同じ日かどうかの判定はUTC基準で行われます
 4. **Supabase設定**: `SUPABASE_URL`と`SUPABASE_KEY`の環境変数が設定されている必要があります
 5. **データ更新**: 同じ日の既存レコードは削除してから新規作成されます（最新1件のみ保持）

--- a/backend/apps/questionnaires/README.md
+++ b/backend/apps/questionnaires/README.md
@@ -1,0 +1,275 @@
+# 朝夜アンケートAPI
+
+朝と夜のアンケート回答を受け付けるAPIエンドポイントです。Supabaseの`users_condition`テーブルに気分と体調のデータを保存します。
+
+## 目次
+
+- [APIエンドポイント](#apiエンドポイント)
+- [リクエスト形式](#リクエスト形式)
+- [レスポンス形式](#レスポンス形式)
+- [使用例](#使用例)
+- [エラーハンドリング](#エラーハンドリング)
+- [データベーステーブル構成](#データベーステーブル構成)
+- [注意事項](#注意事項)
+
+## APIエンドポイント
+
+### 朝アンケート送信
+
+```
+POST /api/questionnaire/morning
+```
+
+### 夜アンケート送信
+
+```
+POST /api/questionnaire/night
+```
+
+## リクエスト形式
+
+### 必須ヘッダー
+
+| ヘッダー名 | 説明 | 例 |
+|-----------|------|-----|
+| `X-User-UUID` | Supabaseの`public.users`テーブルの`uuid` | `550e8400-e29b-41d4-a716-446655440000` |
+| `Content-Type` | リクエストボディの形式 | `application/json` |
+
+### リクエストボディ
+
+```json
+{
+  "mood": "普通",
+  "condition": "軽い",
+  "free_text": ""
+}
+```
+
+#### フィールド説明
+
+| フィールド名 | 型 | 必須 | 説明 |
+|------------|-----|------|------|
+| `mood` | string | 必須 | 気分（選択肢: `"絶好調"`, `"普通"`, `"モヤモヤ"`, `"つらい"`） |
+| `condition` | string | 必須 | 体調（選択肢: `"軽い"`, `"ふつう"`, `"だるい"`） |
+| `free_text` | string | 任意 | 自由入力テキスト（最大1000文字、現在は未使用） |
+
+## レスポンス形式
+
+### 成功時（201 Created）
+
+```json
+{
+  "uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "morning_mood": "普通",
+  "morning_condition": "軽い",
+  "night_mood": null,
+  "night_condition": null,
+  "created_at": "2026-01-29T02:00:00.000Z",
+  "updated_at": "2026-01-29T02:00:00.000Z"
+}
+```
+
+### エラー時（400 Bad Request）
+
+```json
+{
+  "detail": "X-User-UUID ヘッダーが必要です。"
+}
+```
+
+または
+
+```json
+{
+  "mood": ["このフィールドは必須です。"],
+  "condition": ["有効な選択肢ではありません。"]
+}
+```
+
+### エラー時（500 Internal Server Error）
+
+```json
+{
+  "detail": "Supabaseの保存に失敗しました。",
+  "error": "エラーメッセージの詳細"
+}
+```
+
+## 使用例
+
+### cURL
+
+#### 朝アンケート送信
+
+```bash
+curl -X POST http://localhost:8000/api/questionnaire/morning \
+  -H "Content-Type: application/json" \
+  -H "X-User-UUID: 550e8400-e29b-41d4-a716-446655440000" \
+  -d '{
+    "mood": "普通",
+    "condition": "軽い",
+    "free_text": ""
+  }'
+```
+
+#### 夜アンケート送信
+
+```bash
+curl -X POST http://localhost:8000/api/questionnaire/night \
+  -H "Content-Type: application/json" \
+  -H "X-User-UUID: 550e8400-e29b-41d4-a716-446655440000" \
+  -d '{
+    "mood": "モヤモヤ",
+    "condition": "だるい",
+    "free_text": ""
+  }'
+```
+
+### JavaScript / TypeScript (fetch API)
+
+```typescript
+// 朝アンケート送信
+async function submitMorningQuestionnaire(
+  uuid: string,
+  mood: "絶好調" | "普通" | "モヤモヤ" | "つらい",
+  condition: "軽い" | "ふつう" | "だるい"
+) {
+  const response = await fetch("http://localhost:8000/api/questionnaire/morning", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-UUID": uuid,
+    },
+    body: JSON.stringify({
+      mood,
+      condition,
+      free_text: "",
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || "アンケート送信に失敗しました");
+  }
+
+  return await response.json();
+}
+
+// 使用例
+try {
+  const result = await submitMorningQuestionnaire(
+    "550e8400-e29b-41d4-a716-446655440000",
+    "普通",
+    "軽い"
+  );
+  console.log("保存成功:", result);
+} catch (error) {
+  console.error("エラー:", error);
+}
+```
+
+### React Native (既存のApiClientを使用)
+
+```typescript
+import { ApiClient } from "../../api/client";
+
+const client = new ApiClient({
+  baseUrl: "http://localhost:8000",
+  getAuthToken: async () => null, // 認証不要のため
+});
+
+// カスタムヘッダーを追加する必要があるため、直接fetchを使用
+async function submitMorningQuestionnaire(
+  uuid: string,
+  mood: "絶好調" | "普通" | "モヤモヤ" | "つらい",
+  condition: "軽い" | "ふつう" | "だるい"
+) {
+  const response = await fetch("http://localhost:8000/api/questionnaire/morning", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-UUID": uuid,
+    },
+    body: JSON.stringify({
+      mood,
+      condition,
+      free_text: "",
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || "アンケート送信に失敗しました");
+  }
+
+  return await response.json();
+}
+```
+
+## エラーハンドリング
+
+### ステータスコード一覧
+
+| ステータスコード | 説明 |
+|----------------|------|
+| `201 Created` | アンケート回答が正常に保存されました |
+| `400 Bad Request` | リクエストが不正です（UUIDヘッダー未設定、バリデーションエラーなど） |
+| `500 Internal Server Error` | サーバー内部エラー（Supabase接続エラーなど） |
+
+### バリデーションエラー
+
+以下の場合に`400 Bad Request`が返されます：
+
+- `X-User-UUID`ヘッダーが未設定
+- `mood`フィールドが未設定、または選択肢外の値
+- `condition`フィールドが未設定、または選択肢外の値
+
+### エラーレスポンス例
+
+```json
+{
+  "mood": ["このフィールドは必須です。"],
+  "condition": ["有効な選択肢ではありません。"]
+}
+```
+
+## データベーステーブル構成
+
+### users_condition テーブル
+
+| カラム名 | 型 | 説明 |
+|---------|-----|------|
+| `uuid` | text | Supabaseの`public.users`テーブルの`uuid`（主キー） |
+| `morning_mood` | text | 朝の気分（`"絶好調"`, `"普通"`, `"モヤモヤ"`, `"つらい"`のいずれか） |
+| `morning_condition` | text | 朝の体調（`"軽い"`, `"ふつう"`, `"だるい"`のいずれか） |
+| `night_mood` | text | 夜の気分（`"絶好調"`, `"普通"`, `"モヤモヤ"`, `"つらい"`のいずれか） |
+| `night_condition` | text | 夜の体調（`"軽い"`, `"ふつう"`, `"だるい"`のいずれか） |
+| `created_at` | timestamp | レコード作成日時 |
+| `updated_at` | timestamp | レコード更新日時 |
+
+### データ保存の動作
+
+1. **同じ日の既存レコードがある場合**:
+   - 既存レコードを削除してから新規レコードを作成
+   - 朝アンケート送信時: `morning_mood`と`morning_condition`を更新、`night_mood`と`night_condition`は既存値を保持（なければ`null`）
+   - 夜アンケート送信時: `night_mood`と`night_condition`を更新、`morning_mood`と`morning_condition`は既存値を保持（なければ`null`）
+
+2. **同じ日の既存レコードがない場合**:
+   - 新規レコードを作成
+   - 朝アンケート送信時: `morning_mood`と`morning_condition`を設定、`night_mood`と`night_condition`は`null`
+   - 夜アンケート送信時: `night_mood`と`night_condition`を設定、`morning_mood`と`morning_condition`は`null`
+
+## 注意事項
+
+1. **認証**: 現在は認証不要（`AllowAny`）ですが、`X-User-UUID`ヘッダーは必須です
+2. **自由入力**: `free_text`フィールドは現在未使用です。将来的に別テーブルで管理する予定です
+3. **日付判定**: 同じ日かどうかの判定はUTC基準で行われます
+4. **Supabase設定**: `SUPABASE_URL`と`SUPABASE_KEY`の環境変数が設定されている必要があります
+5. **データ更新**: 同じ日の既存レコードは削除してから新規作成されます（最新1件のみ保持）
+
+## 関連ファイル
+
+- `views.py`: APIビューの実装
+- `serializers.py`: リクエスト/レスポンスのシリアライザー
+- `supabase_client.py`: Supabaseクライアントの初期化
+- `urls.py`: URLルーティング設定

--- a/backend/apps/questionnaires/serializers.py
+++ b/backend/apps/questionnaires/serializers.py
@@ -31,7 +31,7 @@ class QuestionnaireRequestSerializer(serializers.Serializer):
         choices=["絶好調", "普通", "モヤモヤ", "つらい"],
     )
     condition = serializers.ChoiceField(
-        choices=["軽い", "ふつう", "だるい"],
+        choices=["軽い", "ふつう", "だるい", "痛い"],
     )
     free_text = serializers.CharField(
         allow_blank=True,

--- a/backend/apps/questionnaires/serializers.py
+++ b/backend/apps/questionnaires/serializers.py
@@ -25,3 +25,17 @@ class AnswerSerializer(serializers.ModelSerializer):
         fields = ["id", "questionnaire", "submitted_at", "payload"]
         read_only_fields = ["submitted_at"]
 
+
+class QuestionnaireRequestSerializer(serializers.Serializer):
+    mood = serializers.ChoiceField(
+        choices=["絶好調", "普通", "モヤモヤ", "つらい"],
+    )
+    condition = serializers.ChoiceField(
+        choices=["軽い", "ふつう", "だるい"],
+    )
+    free_text = serializers.CharField(
+        allow_blank=True,
+        required=False,
+        max_length=1000,
+    )
+

--- a/backend/apps/questionnaires/supabase_client.py
+++ b/backend/apps/questionnaires/supabase_client.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from supabase import Client, create_client
+
+_client: Optional[Client] = None
+
+
+def get_supabase_client() -> Client:
+    """
+    Supabaseクライアントを取得する。
+    環境変数が未設定の場合は例外を投げる。
+    """
+    global _client
+
+    if _client is not None:
+        return _client
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+
+    if not url or not key:
+        raise ValueError("SUPABASE_URL または SUPABASE_KEY が未設定です。")
+
+    _client = create_client(url, key)
+    return _client

--- a/backend/apps/questionnaires/urls.py
+++ b/backend/apps/questionnaires/urls.py
@@ -1,10 +1,21 @@
-from rest_framework.routers import DefaultRouter
+from django.urls import path
 
-from .views import AnswerViewSet, QuestionnaireViewSet
+from backend.apps.common.routers import NoFormatSuffixRouter
 
-router = DefaultRouter()
+from .views import (
+    AnswerViewSet,
+    MorningQuestionnaireView,
+    NightQuestionnaireView,
+    QuestionnaireViewSet,
+)
+
+router = NoFormatSuffixRouter(trailing_slash=False)
 router.register("questionnaires", QuestionnaireViewSet, basename="questionnaire")
 router.register("answers", AnswerViewSet, basename="answer")
 
-urlpatterns = router.urls
+urlpatterns = [
+    path("morning", MorningQuestionnaireView.as_view(), name="questionnaire-morning"),
+    path("night", NightQuestionnaireView.as_view(), name="questionnaire-night"),
+    *router.urls,
+]
 

--- a/backend/apps/questionnaires/views.py
+++ b/backend/apps/questionnaires/views.py
@@ -45,7 +45,7 @@ def _get_user_uuid(request: Request) -> str | None:
 
 
 def _replace_today_condition(
-    uuid: str, is_morning: bool, mood: str, condition: str
+    uuid: str, is_morning: bool, mood: str, condition: str, free_text: str = ""
 ) -> dict:
     """
     同じ日の既存レコードを削除してから、新しいレコードを挿入する。
@@ -76,11 +76,25 @@ def _replace_today_condition(
 
     # 既存レコードがあれば削除
     if existing_result.data:
-        for record in existing_result.data:
+        # idが存在する場合はidで削除、存在しない場合はuuidと日付範囲で削除
+        if isinstance(existing_data, dict) and "id" in existing_data:
+            for record in existing_result.data:
+                if isinstance(record, dict) and "id" in record:
+                    delete_result = (
+                        supabase.table("users_condition")
+                        .delete()
+                        .eq("id", record["id"])
+                        .execute()
+                    )
+                    if getattr(delete_result, "error", None):
+                        raise RuntimeError(delete_result.error)
+        else:
             delete_result = (
                 supabase.table("users_condition")
                 .delete()
-                .eq("id", record["id"])
+                .eq("uuid", uuid)
+                .gte("created_at", today_start.isoformat())
+                .lt("created_at", tomorrow_start.isoformat())
                 .execute()
             )
             if getattr(delete_result, "error", None):
@@ -98,6 +112,12 @@ def _replace_today_condition(
         ),
         "night_condition": (
             condition if not is_morning else existing_data.get("night_condition")
+        ),
+        "morning_note": (
+            free_text if is_morning else existing_data.get("morning_note")
+        ),
+        "night_note": (
+            free_text if not is_morning else existing_data.get("night_note")
         ),
     }
 
@@ -134,6 +154,7 @@ class MorningQuestionnaireView(APIView):
                 True,
                 serializer.validated_data["mood"],
                 serializer.validated_data["condition"],
+                serializer.validated_data.get("free_text", ""),
             )
         except RuntimeError as exc:
             return Response(
@@ -164,6 +185,7 @@ class NightQuestionnaireView(APIView):
                 False,
                 serializer.validated_data["mood"],
                 serializer.validated_data["condition"],
+                serializer.validated_data.get("free_text", ""),
             )
         except RuntimeError as exc:
             return Response(

--- a/backend/apps/questionnaires/views.py
+++ b/backend/apps/questionnaires/views.py
@@ -4,10 +4,20 @@ Questionnaires API endpoints.
 
 from __future__ import annotations
 
-from rest_framework import permissions, viewsets
+from datetime import datetime, timedelta, timezone
+
+from rest_framework import permissions, status, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from .models import Answer, Questionnaire
-from .serializers import AnswerSerializer, QuestionnaireSerializer
+from .serializers import (
+    AnswerSerializer,
+    QuestionnaireRequestSerializer,
+    QuestionnaireSerializer,
+)
+from .supabase_client import get_supabase_client
 
 
 class QuestionnaireViewSet(viewsets.ReadOnlyModelViewSet):
@@ -28,4 +38,138 @@ class AnswerViewSet(viewsets.ModelViewSet):
     queryset = Answer.objects.all()
     serializer_class = AnswerSerializer
     permission_classes = [permissions.AllowAny]
+
+
+def _get_user_uuid(request: Request) -> str | None:
+    return request.headers.get("X-User-UUID")
+
+
+def _replace_today_condition(
+    uuid: str, is_morning: bool, mood: str, condition: str
+) -> dict:
+    """
+    同じ日の既存レコードを削除してから、新しいレコードを挿入する。
+    気分と体調を分離して保存する。
+    """
+    supabase = get_supabase_client()
+
+    today_start = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    tomorrow_start = today_start + timedelta(days=1)
+
+    # 同じ日の既存レコードを検索
+    existing_result = (
+        supabase.table("users_condition")
+        .select("*")
+        .eq("uuid", uuid)
+        .gte("created_at", today_start.isoformat())
+        .lt("created_at", tomorrow_start.isoformat())
+        .execute()
+    )
+
+    if getattr(existing_result, "error", None):
+        raise RuntimeError(existing_result.error)
+
+    # 既存レコードから値を取得（朝/夜の別のフィールドを保持）
+    existing_data = existing_result.data[0] if existing_result.data else {}
+
+    # 既存レコードがあれば削除
+    if existing_result.data:
+        for record in existing_result.data:
+            delete_result = (
+                supabase.table("users_condition")
+                .delete()
+                .eq("id", record["id"])
+                .execute()
+            )
+            if getattr(delete_result, "error", None):
+                raise RuntimeError(delete_result.error)
+
+    # 新しいレコードを作成（朝/夜の別のフィールドを適切に設定）
+    insert_payload = {
+        "uuid": uuid,
+        "morning_mood": mood if is_morning else existing_data.get("morning_mood"),
+        "morning_condition": (
+            condition if is_morning else existing_data.get("morning_condition")
+        ),
+        "night_mood": (
+            mood if not is_morning else existing_data.get("night_mood")
+        ),
+        "night_condition": (
+            condition if not is_morning else existing_data.get("night_condition")
+        ),
+    }
+
+    insert_result = (
+        supabase.table("users_condition").insert(insert_payload).execute()
+    )
+
+    if getattr(insert_result, "error", None):
+        raise RuntimeError(insert_result.error)
+
+    if insert_result.data:
+        return insert_result.data[0]
+
+    return insert_payload
+
+
+class MorningQuestionnaireView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request: Request) -> Response:
+        uuid = _get_user_uuid(request)
+        if not uuid:
+            return Response(
+                {"detail": "X-User-UUID ヘッダーが必要です。"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = QuestionnaireRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            data = _replace_today_condition(
+                uuid,
+                True,
+                serializer.validated_data["mood"],
+                serializer.validated_data["condition"],
+            )
+        except RuntimeError as exc:
+            return Response(
+                {"detail": "Supabaseの保存に失敗しました。", "error": str(exc)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        return Response(data, status=status.HTTP_201_CREATED)
+
+
+class NightQuestionnaireView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request: Request) -> Response:
+        uuid = _get_user_uuid(request)
+        if not uuid:
+            return Response(
+                {"detail": "X-User-UUID ヘッダーが必要です。"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = QuestionnaireRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            data = _replace_today_condition(
+                uuid,
+                False,
+                serializer.validated_data["mood"],
+                serializer.validated_data["condition"],
+            )
+        except RuntimeError as exc:
+            return Response(
+                {"detail": "Supabaseの保存に失敗しました。", "error": str(exc)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        return Response(data, status=status.HTTP_201_CREATED)
 

--- a/backend/apps/quests/urls.py
+++ b/backend/apps/quests/urls.py
@@ -1,8 +1,8 @@
-from rest_framework.routers import DefaultRouter
+from backend.apps.common.routers import NoFormatSuffixRouter
 
 from .views import QuestViewSet
 
-router = DefaultRouter()
+router = NoFormatSuffixRouter(trailing_slash=False)
 router.register("quests", QuestViewSet, basename="quest")
 
 urlpatterns = router.urls

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -11,10 +11,21 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
 from django.core.management.utils import get_random_secret_key
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# .env.localファイルを読み込む（存在する場合）
+env_local_path = BASE_DIR.parent / ".env.local"
+if env_local_path.exists():
+    load_dotenv(env_local_path)
+else:
+    # .env.localが存在しない場合は.envを読み込む
+    env_path = BASE_DIR.parent / ".env"
+    if env_path.exists():
+        load_dotenv(env_path)
 
 
 def _env(name: str, default: str | None = None) -> str:
@@ -139,6 +150,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 20,
+    "URL_FORMAT_OVERRIDE": None,  # format_suffix_patternsを無効化
 }
 
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -17,15 +17,14 @@ from django.core.management.utils import get_random_secret_key
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# .env.localファイルを読み込む（存在する場合）
+env_path = BASE_DIR.parent / ".env"
+if env_path.exists():
+    load_dotenv(env_path)
+
+# 次に .env.local を読み込んでオーバーライド（存在する場合）
 env_local_path = BASE_DIR.parent / ".env.local"
 if env_local_path.exists():
-    load_dotenv(env_local_path)
-else:
-    # .env.localが存在しない場合は.envを読み込む
-    env_path = BASE_DIR.parent / ".env"
-    if env_path.exists():
-        load_dotenv(env_path)
+    load_dotenv(env_local_path, override=True)
 
 
 def _env(name: str, default: str | None = None) -> str:

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("api/mascots/", include("backend.apps.mascots.urls")),
     path("api/logs/", include("backend.apps.logs.urls")),
     path("api/questionnaires/", include("backend.apps.questionnaires.urls")),
+    path("api/questionnaire/", include("backend.apps.questionnaires.urls")),
     path("api/ai/", include("backend.apps.ai.urls")),
 ]
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,6 @@
 django==6.0.1
 djangorestframework==3.15.2
 django-cors-headers==4.4.0
+supabase>=2.0.0
+python-dotenv>=1.0.0
 

--- a/manage.py
+++ b/manage.py
@@ -6,10 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault(
-    'DJANGO_SETTINGS_MODULE',
-    'config.settings.local'
-    )
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.config.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
このプルリクエストでは、朝／夜のアンケート用 API エンドポイントを新たに追加し、ユーザーの気分や体調データを Supabase に保存できるようにしました。また、ルーターの扱いや環境設定を改善するために Django バックエンドのリファクタリングも行っています。変更内容には、新しい API ビューやシリアライザ、Supabase 連携、ドキュメントの追加、ルーティングおよび環境管理の更新が含まれます。

**アンケート API と Supabase 連携**

* アンケート回答を送信するための `MorningQuestionnaireView` および `NightQuestionnaireView` API エンドポイントを実装しました。回答データは Supabase の `users_condition` テーブルに保存され、同日のデータが存在する場合は置き換え処理を行います。カスタムエラーハンドリングとバリデーションも含まれています。[[1]](diffhunk://#diff-368b1d5cda524895841032cd08b7d9f81355589d9878e2d96af8bb293d910be3R42-R175) [[2]](diffhunk://#diff-fdc0da47d8b9c90cd8067697899ed933e2d879b0e46997aaba54738eb1ce24d4R1-R28)
* 気分や体調の選択式フィールド、および任意の自由記述フィールドを含むリクエストデータを検証するための `QuestionnaireRequestSerializer` を追加しました。
* エンドポイント、リクエスト／レスポンス形式、エラーハンドリング、Supabase のテーブル構造を詳細に説明した包括的な API ドキュメントを `backend/apps/questionnaires/README.md` に作成しました。

**ルーターおよびルーティングの改善**

* フォーマットサフィックスによるパターン衝突を防ぐために `NoFormatSuffixRouter` を導入し、すべてのアプリのルーターを `DefaultRouter` からこちらに置き換えました。これにより、末尾スラッシュの挙動を統一し、重複したコンバーターエラーを回避しています。[[1]](diffhunk://#diff-a37d1e55c8cb577420b5154ab6409ccc8e43130ddc6abe664246d2a82b41fb44R1-R14) [[2]](diffhunk://#diff-7dee0d85d65a1a1c68171e46eff9281cd4508e1efdb3f65c0de969131c1686f2L2-R7) [[3]](diffhunk://#diff-24b0f1cadc9badb2e53a68a718356223b47b249234826e29ec210661557e1beaL1-R5) [[4]](diffhunk://#diff-6bffad44cc8015e14f555e5ee53a31e31e31c2e61dc64860d5ade23662d709dcL1-R5) [[5]](diffhunk://#diff-4e826ed403e6bca40033973591b0ec848183dd63ad10f01ac00b1ec23ea34056L1-R5) [[6]](diffhunk://#diff-b13e618e74cd7977a0042c8efb0180e4dbb9d6cb7b1f48b507bd3f84e73ac220L1-R5) [[7]](diffhunk://#diff-a369595c82a99f110706a75bc9c64397052355b49b10fb658f945f6315e400c7L1-R20)
* グローバルな Django REST Framework の設定を更新し、`URL_FORMAT_OVERRIDE` を使用して `format_suffix_patterns` を無効化しました。

**環境設定およびコンフィグレーション**

* Django、Supabase、CORS 設定などの環境変数を記載した `.env.example` を追加しました。
* `python-dotenv` を利用して `.env.local` と `.env` の両方を読み込めるように設定の読み込み方法を改善しました。
* `requirements.txt` に Supabase および dotenv の依存関係を追加しました。
* `manage.py` における `DJANGO_SETTINGS_MODULE` の使用方法を標準化しました。

**その他の細かな変更**

* `backend/apps/common/__init__.py` にモジュールドキュメント文字列を追加しました。
* 互換性のため、`backend/config/urls.py` にアンケート API 用のセカンダリルートを追加しました。