### PR TITLE
feat: OpenAIを利用したクエストとマスコット状態生成機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ DJANGO_DB_PORT=
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_KEY=your-supabase-service-or-anon-key
 
+# OpenAI設定
+OPENAI_API_KEY=your-openai-api-key
+
 # CORS設定
 CORS_ALLOW_ALL_ORIGINS=true
 CORS_ALLOWED_ORIGINS=

--- a/backend/apps/ai/README.md
+++ b/backend/apps/ai/README.md
@@ -1,0 +1,118 @@
+# AI アプリ
+
+ユーザーのメンタルヘルスをサポートするAI機能を提供します。
+
+## エンドポイント
+
+### POST /api/ai/recommendations/
+
+ユーザーの `users_condition` を元に、AIがクエスト（5件）とマスコット状態を生成し、Supabaseに保存します。
+
+#### リクエスト
+
+**ヘッダー:**
+```
+X-User-UUID: <ユーザーのUUID> (必須)
+```
+
+**ボディ:** 不要
+
+#### レスポンス
+
+**成功時 (200):**
+```json
+{
+  "quests": [
+    {
+      "title": "5分間の深呼吸",
+      "description": "朝の気分が少し重そうなので、リラックスのための深呼吸をおすすめします。"
+    },
+    ...
+  ],
+  "mascot": {
+    "status": "Okay",
+    "message": "今日は少しゆっくりいこう！無理しないでね。"
+  }
+}
+```
+
+**エラー時 (400):**
+```json
+{
+  "error": "X-User-UUID ヘッダーが必要です"
+}
+```
+または
+```json
+{
+  "error": "users_condition が見つかりません"
+}
+```
+
+#### 保存先
+
+- **quests テーブル**: 当日分のクエストを5件保存（既存の当日分は削除してから挿入）
+- **mascots テーブル**: マスコット状態を保存（既存があれば更新）
+
+---
+
+### POST /api/ai/hints/
+
+プロンプトに対するヒントを返す（ダミー実装）。
+
+#### リクエスト
+
+**ボディ:**
+```json
+{
+  "prompt": "質問やプロンプト"
+}
+```
+
+#### レスポンス
+
+```json
+{
+  "hint": "Hint for: 質問やプロンプト..."
+}
+```
+
+---
+
+## 環境変数
+
+| 変数名 | 説明 |
+|--------|------|
+| `OPENAI_API_KEY` | OpenAI APIキー |
+| `SUPABASE_URL` | Supabase プロジェクトURL |
+| `SUPABASE_KEY` | Supabase APIキー |
+
+## 依存関係
+
+```
+openai
+supabase
+```
+
+## データベーススキーマ
+
+### users_condition (入力)
+- `uuid`: ユーザーUUID
+- `morning_mood`: 朝の気分
+- `morning_condition`: 朝の体調
+- `morning_note`: 朝のメモ
+- `night_mood`: 夜の気分
+- `night_condition`: 夜の体調
+- `night_note`: 夜のメモ
+
+### quests (出力)
+- `uuid`: ユーザーUUID
+- `title`: クエストタイトル
+- `description`: クエスト説明
+- `completed`: 完了フラグ
+- `day`: 日付
+
+### mascots (出力)
+- `uuid`: ユーザーUUID
+- `status`: Sad / Bad / Okay / Good / Great
+- `message`: マスコットからのメッセージ

--- a/backend/apps/ai/services.py
+++ b/backend/apps/ai/services.py
@@ -6,6 +6,15 @@ AI-related service functions.
 
 from __future__ import annotations
 
+import json
+import os
+from datetime import date
+from typing import Any
+
+from openai import OpenAI
+
+from .supabase_client import get_supabase_client
+
 
 def generate_hint(prompt: str) -> str:
     """
@@ -15,4 +24,191 @@ def generate_hint(prompt: str) -> str:
     """
 
     return f"Hint for: {prompt[:50]}..."
+
+
+# --- AI Recommendations ---
+
+QUEST_SELECTION_TOOLS = [
+    {
+        "type": "function",
+        "name": "save_recommendations",
+        "description": "ユーザーの状態に基づいてクエストとマスコットの状態を保存する",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "quests": {
+                    "type": "array",
+                    "description": "ユーザーに提案するクエスト5件",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string",
+                                "description": "クエストのタイトル",
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "クエストの説明（なぜこのクエストを選んだか含む）",
+                            },
+                        },
+                        "required": ["title", "description"],
+                        "additionalProperties": False,
+                    },
+                },
+                "mascot": {
+                    "type": "object",
+                    "description": "マスコットの状態",
+                    "properties": {
+                        "status": {
+                            "type": "string",
+                            "enum": ["Sad", "Bad", "Okay", "Good", "Great"],
+                            "description": "マスコットの気分状態",
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "マスコットからユーザーへのメッセージ",
+                        },
+                    },
+                    "required": ["status", "message"],
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["quests", "mascot"],
+            "additionalProperties": False,
+        },
+        "strict": True,
+    },
+]
+
+SYSTEM_PROMPT = """あなたはユーザーのメンタルヘルスをサポートするAIアシスタントです。
+                    ユーザーの朝と夜の気分・体調データを分析し、適切なクエスト（軽いタスク）を提案してください。
+
+                    クエストは以下の観点で選んでください：
+                    - ユーザーの現在の気分や体調に合った難易度
+                    - ストレス軽減や気分転換に役立つもの
+                    - 達成感を得やすい小さな目標
+
+                マスコットの状態は、ユーザーの気分を反映させつつ、励ましのメッセージを添えてください。"""
+
+
+def get_user_condition(user_uuid: str) -> dict[str, Any] | None:
+    """Supabaseからユーザーの最新のconditionを取得"""
+    client = get_supabase_client()
+    result = (
+        client.table("users_condition")
+        .select("*")
+        .eq("uuid", user_uuid)
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    if result.data:
+        return result.data[0]
+    return None
+
+
+def save_quests(user_uuid: str, quests: list[dict[str, str]], today: date) -> None:
+    """当日のクエストを保存（既存の当日分は削除）"""
+    client = get_supabase_client()
+
+    # 当日分を削除
+    client.table("quests").delete().eq("uuid", user_uuid).eq(
+        "day", today.isoformat()
+    ).execute()
+
+    # 新規クエストを挿入
+    records = [
+        {
+            "uuid": user_uuid,
+            "title": q["title"],
+            "description": q["description"],
+            "completed": False,
+            "day": today.isoformat(),
+        }
+        for q in quests
+    ]
+    client.table("quests").insert(records).execute()
+
+
+def save_mascot(user_uuid: str, mascot: dict[str, str]) -> None:
+    """マスコット状態を保存（既存があれば更新）"""
+    client = get_supabase_client()
+
+    existing = (
+        client.table("mascots").select("id").eq("uuid", user_uuid).limit(1).execute()
+    )
+
+    if existing.data:
+        client.table("mascots").update(
+            {"status": mascot["status"], "message": mascot["message"]}
+        ).eq("uuid", user_uuid).execute()
+    else:
+        client.table("mascots").insert(
+            {
+                "uuid": user_uuid,
+                "status": mascot["status"],
+                "message": mascot["message"],
+            }
+        ).execute()
+
+
+def generate_recommendations(user_uuid: str) -> dict[str, Any]:
+    """
+    ユーザーのconditionを元にOpenAIでクエスト・マスコット状態を生成し、Supabaseに保存する。
+
+    Returns:
+        dict: {"quests": [...], "mascot": {...}} or {"error": "..."}
+    """
+    # 1. users_condition を取得
+    condition = get_user_condition(user_uuid)
+    if not condition:
+        return {"error": "users_condition が見つかりません"}
+
+    # 2. OpenAIへのプロンプトを構築
+    user_input = f"""ユーザーの状態:
+            - 朝の気分: {condition.get("morning_mood", "未入力")}
+            - 朝の体調: {condition.get("morning_condition", "未入力")}
+            - 朝のメモ: {condition.get("morning_note", "未入力")}
+            - 夜の気分: {condition.get("night_mood", "未入力")}
+            - 夜の体調: {condition.get("night_condition", "未入力")}
+            - 夜のメモ: {condition.get("night_note", "未入力")}
+
+            この情報を元に、5つのクエストとマスコットの状態を生成してください。"""
+
+    # 3. OpenAI API呼び出し (function calling)
+    openai_client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+    response = openai_client.responses.create(
+        model="gpt-5.2",
+        input=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_input},
+        ],
+        tools=QUEST_SELECTION_TOOLS,
+    )
+
+    # 4. Function call結果をパース
+    function_call = None
+    for item in response.output:
+        if item.type == "function_call" and item.name == "save_recommendations":
+            function_call = item
+            break
+
+    if not function_call:
+        return {"error": "AIからの応答が不正です"}
+
+    try:
+        args = json.loads(function_call.arguments)
+    except json.JSONDecodeError:
+        return {"error": "AIからの応答をパースできませんでした"}
+
+    quests = args.get("quests", [])
+    mascot = args.get("mascot", {})
+
+    # 5. Supabaseに保存
+    today = date.today()
+    save_quests(user_uuid, quests, today)
+    save_mascot(user_uuid, mascot)
+
+    return {"quests": quests, "mascot": mascot}
 

--- a/backend/apps/ai/supabase_client.py
+++ b/backend/apps/ai/supabase_client.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from supabase import Client, create_client
+
+_client: Optional[Client] = None
+
+
+def get_supabase_client() -> Client:
+    """
+    Supabaseクライアントを取得する。
+    環境変数が未設定の場合は例外を投げる。
+    """
+    global _client
+
+    if _client is not None:
+        return _client
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+
+    if not url or not key:
+        raise ValueError("SUPABASE_URL または SUPABASE_KEY が未設定です。")
+
+    _client = create_client(url, key)
+    return _client

--- a/backend/apps/ai/urls.py
+++ b/backend/apps/ai/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from .views import HintView
+from .views import HintView, RecommendationsView
 
 urlpatterns = [
     path("hints/", HintView.as_view(), name="ai-hints"),
+    path("recommendations/", RecommendationsView.as_view(), name="ai-recommendations"),
 ]
 

--- a/backend/apps/ai/views.py
+++ b/backend/apps/ai/views.py
@@ -9,7 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .services import generate_hint
+from .services import generate_hint, generate_recommendations
 
 
 class HintView(APIView):
@@ -34,4 +34,36 @@ class HintView(APIView):
             )
         hint = generate_hint(prompt)
         return Response({"hint": hint})
+
+
+class RecommendationsView(APIView):
+    """
+    POST /api/ai/recommendations/
+
+    ユーザーのconditionを元にAIがクエストとマスコット状態を生成しSupabaseに保存する。
+
+    リクエストヘッダー:
+    - X-User-UUID: string (必須)
+
+    レスポンス:
+    - 成功時: { "quests": [...], "mascot": {...} }
+    - エラー時: { "error": "..." }
+    """
+
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request: Request) -> Response:
+        user_uuid = request.headers.get("X-User-UUID")
+        if not user_uuid:
+            return Response(
+                {"error": "X-User-UUID ヘッダーが必要です"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        result = generate_recommendations(user_uuid)
+
+        if "error" in result:
+            return Response(result, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(result, status=status.HTTP_200_OK)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,4 +3,5 @@ djangorestframework==3.15.2
 django-cors-headers==4.4.0
 supabase>=2.0.0
 python-dotenv>=1.0.0
+openai>=1.0.0
 


### PR DESCRIPTION
- 新しいRecommendationsViewを追加し、ユーザーの状態に基づいてAIがクエストとマスコットの状態を生成し、Supabaseに保存する機能を実装しました。
- .env.exampleにOpenAIのAPIキー設定を追加し、requirements.txtにopenaiライブラリを追加しました。
- services.pyにAI関連のロジックを実装し、ユーザーの状態を取得してAIにプロンプトを送信する機能を追加しました。
- 新しいAPIエンドポイント/api/ai/recommendations/を追加しました。