### PR TITLE
feat: users_conditionの履歴管理とマスコット状態判定の改善

### DIFF
--- a/backend/apps/ai/services.py
+++ b/backend/apps/ai/services.py
@@ -91,6 +91,7 @@ SYSTEM_PROMPT = """
 - 「体調が優れない場合」→ 無理をせず負担の少ない心身ケアのクエスト（例：深呼吸、ストレッチ、やさしく体を休める）が最優先。
 - 難易度は状態に応じて最適化し、ユーザーが達成感を得る小さなステップとなるよう配慮してください。
 - マスコットはユーザーの現在の気分・体調を反映しつつ、前向き・励ましのメッセージを添えてください。
+- **最新2件のうち両方で気分が「つらい」になっている場合のみ**、マスコットの状態を「Bad」または「Sad」にしてください。1件だけ「つらい」の場合は急に「Bad」「Sad」にしないでください。
 
 **必ず以下の順番・流れで出力してください：**
 1. ユーザーの状態分析と判断根拠（reasoningを必ず明示。なぜその提案をするのかを論理的に）
@@ -174,20 +175,24 @@ SYSTEM_PROMPT = """
 """
 
 
-def get_user_condition(user_uuid: str) -> dict[str, Any] | None:
-    """Supabaseからユーザーの最新のconditionを取得"""
+def get_user_conditions(user_uuid: str, limit: int = 2) -> list[dict[str, Any]]:
+    """Supabaseからユーザーの最新N件のconditionを取得"""
     client = get_supabase_client()
     result = (
         client.table("users_condition")
         .select("*")
         .eq("uuid", user_uuid)
         .order("created_at", desc=True)
-        .limit(1)
+        .limit(limit)
         .execute()
     )
-    if result.data:
-        return result.data[0]
-    return None
+    return result.data if result.data else []
+
+
+def get_user_condition(user_uuid: str) -> dict[str, Any] | None:
+    """Supabaseからユーザーの最新のconditionを取得（後方互換）"""
+    conditions = get_user_conditions(user_uuid, limit=1)
+    return conditions[0] if conditions else None
 
 
 def save_quests(user_uuid: str, quests: list[dict[str, str]], today: date) -> None:
@@ -242,21 +247,44 @@ def generate_recommendations(user_uuid: str) -> dict[str, Any]:
     Returns:
         dict: {"quests": [...], "mascot": {...}} or {"error": "..."}
     """
-    # 1. users_condition を取得
-    condition = get_user_condition(user_uuid)
-    if not condition:
+
+    def _get_value(condition: dict[str, Any] | None, key: str, default: str) -> Any:
+        if not condition:
+            return default
+        value = condition.get(key)
+        return default if value in (None, "") else value
+
+    # 1. users_condition を取得（最新2件: 最新 + 1つ前）
+    conditions = get_user_conditions(user_uuid, limit=2)
+    if not conditions:
         return {"error": "users_condition が見つかりません"}
 
-    # 2. OpenAIへのプロンプトを構築
-    user_input = f"""ユーザーの状態:
-            - 朝の気分: {condition.get("morning_mood", "未入力")}
-            - 朝の体調: {condition.get("morning_condition", "未入力")}
-            - 朝のメモ: {condition.get("morning_note", "未入力")}
-            - 夜の気分: {condition.get("night_mood", "未入力")}
-            - 夜の体調: {condition.get("night_condition", "未入力")}
-            - 夜のメモ: {condition.get("night_note", "未入力")}
+    latest = conditions[0]
+    previous = conditions[1] if len(conditions) > 1 else None
 
-            この情報を元に、5つのクエストとマスコットの状態を生成してください。"""
+    # 2. OpenAIへのプロンプトを構築
+    user_input = f"""ユーザーの状態（最新2件）:
+
+【最新】(created_at: {_get_value(latest, "created_at", "不明")})
+- 朝の気分: {_get_value(latest, "morning_mood", "未入力")}
+- 朝の体調: {_get_value(latest, "morning_condition", "未入力")}
+- 朝のメモ: {_get_value(latest, "morning_note", "未入力")}
+- 夜の気分: {_get_value(latest, "night_mood", "未入力")}
+- 夜の体調: {_get_value(latest, "night_condition", "未入力")}
+- 夜のメモ: {_get_value(latest, "night_note", "未入力")}
+
+【1つ前】(created_at: {_get_value(previous, "created_at", "データなし")})
+- 朝の気分: {_get_value(previous, "morning_mood", "データなし")}
+- 朝の体調: {_get_value(previous, "morning_condition", "データなし")}
+- 朝のメモ: {_get_value(previous, "morning_note", "データなし")}
+- 夜の気分: {_get_value(previous, "night_mood", "データなし")}
+- 夜の体調: {_get_value(previous, "night_condition", "データなし")}
+- 夜のメモ: {_get_value(previous, "night_note", "データなし")}
+
+【重要】マスコットのstatusは、最新2件のうち両方で気分が「つらい」になっている場合のみ「Bad」または「Sad」にしてください。
+1件だけ「つらい」の場合は、急に「Bad」「Sad」にしないでください。
+
+この情報を元に、5つのクエストとマスコットの状態を生成してください。"""
 
     # 3. OpenAI API呼び出し (function calling)
     openai_client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))

--- a/backend/apps/questionnaires/README.md
+++ b/backend/apps/questionnaires/README.md
@@ -269,7 +269,7 @@ async function submitMorningQuestionnaire(
 2. **自由入力**: `free_text`フィールドは、朝アンケートの場合は`morning_note`、夜アンケートの場合は`night_note`として`users_condition`テーブルに保存されます
 3. **日付判定**: 同じ日かどうかの判定はUTC基準で行われます
 4. **Supabase設定**: `SUPABASE_URL`と`SUPABASE_KEY`の環境変数が設定されている必要があります
-5. **データ更新**: 同じ日の既存レコードは削除してから新規作成されます（最新1件のみ保持）
+5. **データ更新**: 同じ日の既存レコードは削除してから新規作成されます（当日分は1件に統合）。また、`users_condition` はユーザーごとに直近2件のみ保持し、古いデータは削除されます。
 
 ## 関連ファイル
 

--- a/backend/apps/questionnaires/views.py
+++ b/backend/apps/questionnaires/views.py
@@ -50,6 +50,8 @@ def _replace_today_condition(
     """
     同じ日の既存レコードを削除してから、新しいレコードを挿入する。
     気分と体調を分離して保存する。
+
+    併せて、users_condition が肥大化しないように、各ユーザー直近2件のみ保持する。
     """
     supabase = get_supabase_client()
 
@@ -71,8 +73,42 @@ def _replace_today_condition(
     if getattr(existing_result, "error", None):
         raise RuntimeError(existing_result.error)
 
-    # 既存レコードから値を取得（朝/夜の別のフィールドを保持）
     existing_data = existing_result.data[0] if existing_result.data else {}
+    
+    if not existing_data:
+        latest_result = (
+            supabase.table("users_condition")
+            .select("*")
+            .eq("uuid", uuid)
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        
+        if getattr(latest_result, "error", None):
+            raise RuntimeError(latest_result.error)
+        
+        if latest_result.data:
+            latest_record = latest_result.data[0]
+
+            latest_created_at_str = latest_record.get("created_at")
+            if latest_created_at_str:
+                if isinstance(latest_created_at_str, str):
+                    latest_created_at_str = latest_created_at_str.replace("Z", "+00:00")
+                    try:
+                        latest_created_at = datetime.fromisoformat(latest_created_at_str)
+                    except (ValueError, AttributeError):
+                        latest_created_at = None
+                elif isinstance(latest_created_at_str, datetime):
+                    latest_created_at = latest_created_at_str
+                else:
+                    latest_created_at = None
+                
+                # 最新レコードが今日または昨日のものである場合のみ使用
+                if latest_created_at and latest_created_at.tzinfo is None:
+                    latest_created_at = latest_created_at.replace(tzinfo=timezone.utc)
+                if latest_created_at and latest_created_at >= today_start - timedelta(days=1):
+                    existing_data = latest_record
 
     # 既存レコードがあれば削除
     if existing_result.data:
@@ -121,12 +157,34 @@ def _replace_today_condition(
         ),
     }
 
-    insert_result = (
-        supabase.table("users_condition").insert(insert_payload).execute()
-    )
+    insert_result = supabase.table("users_condition").insert(insert_payload).execute()
 
     if getattr(insert_result, "error", None):
         raise RuntimeError(insert_result.error)
+
+    # 履歴肥大化防止: 各ユーザー直近2件のみ保持
+    prune_result = (
+        supabase.table("users_condition")
+        .select("created_at")
+        .eq("uuid", uuid)
+        .order("created_at", desc=True)
+        .limit(3)
+        .execute()
+    )
+    if getattr(prune_result, "error", None):
+        raise RuntimeError(prune_result.error)
+
+    if prune_result.data and len(prune_result.data) > 2:
+        cutoff = prune_result.data[1]["created_at"]
+        delete_old_result = (
+            supabase.table("users_condition")
+            .delete()
+            .eq("uuid", uuid)
+            .lt("created_at", cutoff)
+            .execute()
+        )
+        if getattr(delete_old_result, "error", None):
+            raise RuntimeError(delete_old_result.error)
 
     if insert_result.data:
         return insert_result.data[0]


### PR DESCRIPTION
## 概要

users_conditionテーブルの履歴肥大化を防ぐため、各ユーザー直近2件のみ保持する機能を追加しました。また、マスコットの状態判定を改善し、最新2件の気分データを参照するように変更しました。

## 変更内容

- `get_user_conditions`関数を追加し、最新N件のconditionを取得可能に
- `generate_recommendations`関数で最新2件のconditionを参照するように変更
- 最新2件のうち両方で気分が「つらい」の場合のみマスコットを「Bad」または「Sad」にする判定ロジックを追加
- `_replace_today_condition`関数に履歴肥大化防止処理を追加（各ユーザー直近2件のみ保持）
- READMEに直近2件のみ保持する仕様を追記

## 技術的な詳細

- Supabaseのクエリで`order`と`limit`を使用して最新N件を取得
- 古いデータは`lt`条件で削除
- マスコット状態判定は最新2件のデータを分析して決定

## テスト内容

- 手動でアンケート送信を複数回実行し、直近2件のみ保持されることを確認
- マスコット状態判定が最新2件の気分データを正しく参照することを確認

Made with [Cursor](https://cursor.com)