### PR TITLE
fix: 修正SupabaseクライアントのURL処理と画像アップロードオプション

### DIFF
--- a/backend/apps/ai/storage_service.py
+++ b/backend/apps/ai/storage_service.py
@@ -36,7 +36,8 @@ def upload_mascot_images(user_uuid: str, image_data_list: List[bytes]) -> Dict[s
         client.storage.from_(bucket).upload(
             file_name,
             image_data,
-            file_options={"content-type": "image/png", "upsert": True},
+            # Supabase expects header values as str/bytes; avoid bool in headers.
+            file_options={"content-type": "image/png", "upsert": "true"},
         )
         public_url_raw = client.storage.from_(bucket).get_public_url(file_name)
         image_urls[mood] = _extract_public_url(public_url_raw)

--- a/backend/apps/ai/supabase_client.py
+++ b/backend/apps/ai/supabase_client.py
@@ -26,5 +26,8 @@ def get_supabase_client() -> Client:
             "SUPABASE_URL または SUPABASE_SERVICE_KEY/SUPABASE_KEY が未設定です。"
         )
 
+    if not url.endswith("/"):
+        url = f"{url}/"
+
     _client = create_client(url, key)
     return _client

--- a/backend/apps/questionnaires/supabase_client.py
+++ b/backend/apps/questionnaires/supabase_client.py
@@ -24,5 +24,8 @@ def get_supabase_client() -> Client:
     if not url or not key:
         raise ValueError("SUPABASE_URL または SUPABASE_KEY が未設定です。")
 
+    if not url.endswith("/"):
+        url = f"{url}/"
+
     _client = create_client(url, key)
     return _client

--- a/backend/apps/quests/supabase_client.py
+++ b/backend/apps/quests/supabase_client.py
@@ -24,5 +24,8 @@ def get_supabase_client() -> Client:
     if not url or not key:
         raise ValueError("SUPABASE_URL または SUPABASE_KEY が未設定です。")
 
+    if not url.endswith("/"):
+        url = f"{url}/"
+
     _client = create_client(url, key)
     return _client


### PR DESCRIPTION
- upload_mascot_images関数内で、画像アップロードのfile_optionsの"upsert"をboolからstrに変更
- Supabaseクライアントのget_supabase_client関数で、URLが"/"で終わらない場合に追加する処理を追加