### PR TITLE
refactor: 画像生成モデルを gemini-3-pro から gemini-2.5-flash に移行

### DIFF
--- a/backend/apps/ai/imagen_service.py
+++ b/backend/apps/ai/imagen_service.py
@@ -165,11 +165,24 @@ def generate_mascot_images(
         contents.append(prompt)
 
         response = client.models.generate_content(
-            model="gemini-3-pro-image-preview",
+            model="gemini-2.5-flash-image",
             contents=contents,
+            config=types.GenerateContentConfig(
+                response_modalities=["IMAGE"],
+                image_config=types.ImageConfig(
+                    aspect_ratio="1:1",
+                ),
+            ),
         )
-        image_part = response.candidates[0].content.parts[0]
-        return _normalize_image_bytes(image_part.inline_data.data)
+        parts = response.candidates[0].content.parts
+        image_data = None
+        for part in parts:
+            if part.inline_data is not None and part.inline_data.data is not None:
+                image_data = _normalize_image_bytes(part.inline_data.data)
+                break
+        if image_data is None:
+            raise ValueError("No image data found in model response")
+        return image_data
 
     try:
         anchor_mood = "Okay"

--- a/backend/apps/ai/services.py
+++ b/backend/apps/ai/services.py
@@ -39,7 +39,7 @@ def build_mascot_prompt(
     mood_status: str,
 ) -> str:
     """
-    アンケート結果から Gemini 3 Pro Image Preview 用のプロンプトを生成する。
+    アンケート結果から Gemini 2.5 Flash Image 用のプロンプトを生成する。
     参照画像と組み合わせて既存テイストに寄せる。
     """
 


### PR DESCRIPTION
- モデルIDを gemini-2.5-flash-image に変更（コスト削減・安定性向上）
- GenerateContentConfig で response_modalities と aspect_ratio を指定
- レスポンスパース処理を堅牢化（parts をループして画像データを探索）
- docstring のモデル名を更新